### PR TITLE
Add support for arrays

### DIFF
--- a/internal/mockgen/generation/generate_type.go
+++ b/internal/mockgen/generation/generate_type.go
@@ -15,6 +15,8 @@ func generateType(typ types.Type, importPath, outputImportPath string, variadic 
 	}
 
 	switch t := typ.(type) {
+	case *types.Array:
+		return generateArrayType(t, recur)
 	case *types.Basic:
 		return generateBasicType(t, recur)
 	case *types.Chan:
@@ -37,6 +39,10 @@ func generateType(typ types.Type, importPath, outputImportPath string, variadic 
 	default:
 		panic(fmt.Sprintf("unsupported case: %#v\n", typ))
 	}
+}
+
+func generateArrayType(t *types.Array, generate typeGenerator) *jen.Statement {
+	return compose(jen.Index(jen.Lit(int(t.Len()))), generate(t.Elem()))
 }
 
 func generateBasicType(t *types.Basic, _ typeGenerator) *jen.Statement {

--- a/internal/mockgen/generation/generate_value.go
+++ b/internal/mockgen/generation/generate_value.go
@@ -8,6 +8,9 @@ import (
 
 func generateZeroValue(typ types.Type, importPath, outputImportPath string) *jen.Statement {
 	switch t := typ.(type) {
+	case *types.Array:
+		return generateType(typ, importPath, outputImportPath, false).Block()
+
 	case *types.Basic:
 		kind := t.Kind()
 


### PR DESCRIPTION
Currently, when trying to generate a mock for an interface that contains functions that have arrays in their signature, the tool fails with:

```
panic: unsupported case: &types.Array{len:2, elem:(*types.Pointer)(0xc0021ffbe0)}


goroutine 1 [running]:
github.com/derision-test/go-mockgen/internal/mockgen/generation.GenerateType({0x7ddb18, 0xc001ee36c8}, {0x7ffe6b025e5c, 0x22}, {0xc00001e750, 0x24}, 0xe6)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/types.go:82 +0x1534
github.com/derision-test/go-mockgen/internal/mockgen/generation.GenerateType.func1(...)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/types.go:22
github.com/derision-test/go-mockgen/internal/mockgen/generation.GenerateType({0x7ddc58, 0xc0021ffbd0}, {0x7ffe6b025e5c, 0x22}, {0xc00001e750, 0x24}, 0x4c)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/types.go:71 +0x5e5
github.com/derision-test/go-mockgen/internal/mockgen/generation.GenerateParamTypes(0xc000972500, {0x7ffe6b025e5c, 0x22}, {0xc00001e750, 0x24}, 0x1)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/signature.go:45 +0x16f
github.com/derision-test/go-mockgen/internal/mockgen/generation.wrapMethod(0xc002e58440, 0xc000972500, {0xc00001e750, 0x24})
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generator.go:105 +0x6b
github.com/derision-test/go-mockgen/internal/mockgen/generation.wrapInterface(0xc002e58440, {0x0, 0x0}, {0xc00508d8b0, 0x7}, {0xc00508d8c0, 0xb}, {0xc00001e750, 0x24})
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generator.go:95 +0x18a
github.com/derision-test/go-mockgen/internal/mockgen/generation.generateInterface(0xc0026ad4a0, 0xc002e58440, {0x0, 0x0}, {0xc00001e750, 0x24})
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generator.go:49 +0x1a6
github.com/derision-test/go-mockgen/internal/mockgen/generation.generateContent({0xc0002dbcf8, 0x1, 0xc0009704b0}, {0xc00001e76f, 0x5}, {0x0, 0x0}, {0xc00001e750, 0x24})
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generate.go:125 +0x2b5
github.com/derision-test/go-mockgen/internal/mockgen/generation.generateAndRender({0xc0002dbcf8, 0x7, 0x10}, {0xc0009704e0, 0x2c}, 0xc000164000)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generate.go:93 +0xd6
github.com/derision-test/go-mockgen/internal/mockgen/generation.generateDirectory({0xc000cb5228, 0x1, 0x7}, 0xc000164000)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generate.go:79 +0x1fe
github.com/derision-test/go-mockgen/internal/mockgen/generation.Generate({0xc000cb5228, 0xc0002dbe20, 0xc00508d887}, 0x7)
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/internal/mockgen/generation/generate.go:24 +0x36
main.mainErr()
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/cmd/go-mockgen/main.go:61 +0x1a5
main.main()
        /home/hexa/go/pkg/mod/github.com/derision-test/go-mockgen@v1.1.3/cmd/go-mockgen/main.go:18 +0x2b
```

This PR adds support for array types, and adds the proper zero value generation for them