### PR TITLE
fix type params on mocks when bound is in same package

### DIFF
--- a/internal/integration/gen.go
+++ b/internal/integration/gen.go
@@ -1,3 +1,4 @@
 package integration
 
+//go:generate go run ../../cmd/go-mockgen ./testdata -f -d ./testdata --disable-formatting
 //go:generate go run ../../cmd/go-mockgen ./testdata -f -d ./testdata/mocks --disable-formatting

--- a/internal/mockgen/generation/generate_constructors.go
+++ b/internal/mockgen/generation/generate_constructors.go
@@ -11,7 +11,7 @@ import (
 
 func generateMockStructConstructor(iface *wrappedInterface, constructorPrefix, outputImportPath string) jen.Code {
 	makeField := func(method *wrappedMethod) jen.Code {
-		return makeDefaultHookField(iface, method, generateNoopFunction(iface, method, outputImportPath))
+		return makeDefaultHookField(iface, method, outputImportPath, generateNoopFunction(iface, method, outputImportPath))
 	}
 
 	name := fmt.Sprintf("New%s%s", constructorPrefix, iface.mockStructName)
@@ -19,12 +19,12 @@ func generateMockStructConstructor(iface *wrappedInterface, constructorPrefix, o
 		fmt.Sprintf(`%s creates a new mock of the %s interface.`, name, iface.Name),
 		`All methods return zero values for all results, unless overwritten.`,
 	}
-	return generateConstructor(iface, strings.Join(commentText, " "), name, nil, makeField)
+	return generateConstructor(iface, strings.Join(commentText, " "), name, nil, outputImportPath, makeField)
 }
 
 func generateMockStructStrictConstructor(iface *wrappedInterface, constructorPrefix, outputImportPath string) jen.Code {
 	makeField := func(method *wrappedMethod) jen.Code {
-		return makeDefaultHookField(iface, method, generatePanickingFunction(iface, method, outputImportPath))
+		return makeDefaultHookField(iface, method, outputImportPath, generatePanickingFunction(iface, method, outputImportPath))
 	}
 
 	name := fmt.Sprintf("NewStrict%s%s", constructorPrefix, iface.mockStructName)
@@ -32,7 +32,7 @@ func generateMockStructStrictConstructor(iface *wrappedInterface, constructorPre
 		fmt.Sprintf(`%s creates a new mock of the %s interface.`, name, iface.Name),
 		`All methods panic on invocation, unless overwritten.`,
 	}
-	return generateConstructor(iface, strings.Join(commentText, " "), name, nil, makeField)
+	return generateConstructor(iface, strings.Join(commentText, " "), name, nil, outputImportPath, makeField)
 }
 
 func generateMockStructFromConstructor(iface *wrappedInterface, constructorPrefix, outputImportPath string) jen.Code {
@@ -40,19 +40,19 @@ func generateMockStructFromConstructor(iface *wrappedInterface, constructorPrefi
 		surrogateStructName := fmt.Sprintf("surrogateMock%s", iface.titleName)
 		surrogateDefinition := generateSurrogateInterface(iface, surrogateStructName)
 		name := jen.Id(surrogateStructName)
-		constructor := generateMockStructFromConstructorCommon(iface, name, constructorPrefix)
+		constructor := generateMockStructFromConstructorCommon(iface, name, constructorPrefix, outputImportPath)
 		return compose(surrogateDefinition, constructor)
 	}
 
 	importPath := sanitizeImportPath(iface.ImportPath, outputImportPath)
 	name := jen.Qual(importPath, iface.Name)
-	return generateMockStructFromConstructorCommon(iface, name, constructorPrefix)
+	return generateMockStructFromConstructorCommon(iface, name, constructorPrefix, outputImportPath)
 }
 
-func generateMockStructFromConstructorCommon(iface *wrappedInterface, ifaceName *jen.Statement, constructorPrefix string) jen.Code {
+func generateMockStructFromConstructorCommon(iface *wrappedInterface, ifaceName *jen.Statement, constructorPrefix, outputImportPath string) jen.Code {
 	makeField := func(method *wrappedMethod) jen.Code {
 		// i.<MethodName>
-		return makeDefaultHookField(iface, method, jen.Id("i").Dot(method.Name))
+		return makeDefaultHookField(iface, method, outputImportPath, jen.Id("i").Dot(method.Name))
 	}
 
 	name := fmt.Sprintf("New%s%sFrom", constructorPrefix, iface.mockStructName)
@@ -62,8 +62,8 @@ func generateMockStructFromConstructorCommon(iface *wrappedInterface, ifaceName 
 	}
 
 	// (i <InterfaceName>)
-	params := []jen.Code{compose(jen.Id("i"), addTypes(ifaceName, iface.TypeParams, false))}
-	return generateConstructor(iface, strings.Join(commentText, " "), name, params, makeField)
+	params := []jen.Code{compose(jen.Id("i"), addTypes(ifaceName, iface.TypeParams, outputImportPath, false))}
+	return generateConstructor(iface, strings.Join(commentText, " "), name, params, outputImportPath, makeField)
 }
 
 func generateConstructor(
@@ -71,6 +71,7 @@ func generateConstructor(
 	commentText string,
 	methodName string,
 	params []jen.Code,
+	outputImportPath string,
 	makeField func(method *wrappedMethod) jen.Code,
 ) jen.Code {
 	constructorFields := make([]jen.Code, 0, len(iface.Methods))
@@ -79,9 +80,9 @@ func generateConstructor(
 	}
 
 	// return &Mock<Name>{ <constructorField>, ... }
-	returnStatement := compose(jen.Return(), generateStructInitializer(iface.mockStructName, iface.TypeParams, constructorFields...))
-	results := []jen.Code{addTypes(jen.Op("*").Id(iface.mockStructName), iface.TypeParams, false)}
-	functionDeclaration := compose(addTypes(jen.Func().Id(methodName), iface.TypeParams, true), jen.Params(params...).Params(results...).Block(returnStatement))
+	returnStatement := compose(jen.Return(), generateStructInitializer(iface.mockStructName, outputImportPath, iface.TypeParams, constructorFields...))
+	results := []jen.Code{addTypes(jen.Op("*").Id(iface.mockStructName), iface.TypeParams, outputImportPath, false)}
+	functionDeclaration := compose(addTypes(jen.Func().Id(methodName), iface.TypeParams, outputImportPath, true), jen.Params(params...).Params(results...).Block(returnStatement))
 	return addComment(functionDeclaration, 1, commentText)
 }
 
@@ -118,11 +119,11 @@ func generateSurrogateInterface(iface *wrappedInterface, surrogateName string) *
 	return addComment(typeDeclaration, 1, surrogateCommentText)
 }
 
-func makeDefaultHookField(iface *wrappedInterface, method *wrappedMethod, function jen.Code) jen.Code {
+func makeDefaultHookField(iface *wrappedInterface, method *wrappedMethod, outputImportPath string, function jen.Code) jen.Code {
 	fieldName := fmt.Sprintf("%sFunc", method.Name)
 	structName := fmt.Sprintf("%s%s%sFunc", iface.prefix, iface.titleName, method.Name)
 
-	initializer := generateStructInitializer(structName, iface.TypeParams, compose(
+	initializer := generateStructInitializer(structName, outputImportPath, iface.TypeParams, compose(
 		jen.Id("defaultHook").Op(":"),
 		function,
 	))
@@ -131,9 +132,9 @@ func makeDefaultHookField(iface *wrappedInterface, method *wrappedMethod, functi
 	return compose(jen.Id(fieldName), jen.Op(":"), initializer)
 }
 
-func generateStructInitializer(structName string, typeParams []types.TypeParam, fields ...jen.Code) jen.Code {
+func generateStructInitializer(structName string, outputImportPath string, typeParams []types.TypeParam, fields ...jen.Code) jen.Code {
 	// &<StructName>{ fields, ... }
-	return compose(addTypes(jen.Op("&").Id(structName), typeParams, false), jen.Values(padFields(fields)...))
+	return compose(addTypes(jen.Op("&").Id(structName), typeParams, outputImportPath, false), jen.Values(padFields(fields)...))
 }
 
 func padFields(fields []jen.Code) []jen.Code {

--- a/internal/mockgen/generation/generate_mock_func_call_methods.go
+++ b/internal/mockgen/generation/generate_mock_func_call_methods.go
@@ -25,7 +25,7 @@ func generateMockFuncCallArgsMethodNonVariadic(iface *wrappedInterface, method *
 	returnStatement := jen.Return().Index().Interface().Values(valueExpressions...)
 
 	results := []jen.Code{jen.Index().Interface()}
-	return generateMockFuncCallMethod(iface, method, "Args", commentText, nil, results,
+	return generateMockFuncCallMethod(iface, outputImportPath, method, "Args", commentText, nil, results,
 		returnStatement, // return []interface{ c.Arg<n>, ... }
 	)
 }
@@ -50,7 +50,7 @@ func generateMockFuncCallArgsMethodVariadic(iface *wrappedInterface, method *wra
 	returnStatement := jen.Return().Append(simpleValuesExpression, jen.Id("trailing").Op("..."))
 
 	results := []jen.Code{jen.Index().Interface()}
-	return generateMockFuncCallMethod(iface, method, "Args", commentText, nil, results,
+	return generateMockFuncCallMethod(iface, outputImportPath, method, "Args", commentText, nil, results,
 		trailingDeclaration,                   // trailingDeclaration := []interface{}
 		loopStatement, jen.Line(), jen.Line(), // for _, val := range Arg<lastIndex> { trailing = append(trailing, val) }
 		returnStatement, // return append([]interface{ <values>, ... }, trailing...)
@@ -68,13 +68,14 @@ func generateMockFuncCallResultsMethod(iface *wrappedInterface, method *wrappedM
 	returnStatement := jen.Return().Index().Interface().Values(values...)
 
 	results := []jen.Code{jen.Index().Interface()}
-	return generateMockFuncCallMethod(iface, method, "Results", commentText, nil, results,
+	return generateMockFuncCallMethod(iface, outputImportPath, method, "Results", commentText, nil, results,
 		returnStatement, // return []interface{ c.Result<n>, ... }
 	)
 }
 
 func generateMockFuncCallMethod(
 	iface *wrappedInterface,
+	outputImportPath string,
 	method *wrappedMethod,
 	methodName string,
 	commentText string,
@@ -82,7 +83,7 @@ func generateMockFuncCallMethod(
 	body ...jen.Code,
 ) jen.Code {
 	mockFuncCallStructName := fmt.Sprintf("%s%s%sFuncCall", iface.prefix, iface.titleName, method.Name)
-	receiver := compose(jen.Id("c"), addTypes(jen.Id(mockFuncCallStructName), iface.TypeParams, false))
+	receiver := compose(jen.Id("c"), addTypes(jen.Id(mockFuncCallStructName), iface.TypeParams, outputImportPath, false))
 	methodDeclaration := jen.Func().Params(receiver).Id(methodName).Params(params...).Params(results...).Block(body...)
 	return addComment(methodDeclaration, 1, commentText)
 }

--- a/internal/mockgen/generation/generate_mock_methods.go
+++ b/internal/mockgen/generation/generate_mock_methods.go
@@ -35,7 +35,7 @@ func generateMockInterfaceMethod(iface *wrappedInterface, method *wrappedMethod,
 
 	functionExpression := jen.Id("m").Dot(mockFuncFieldName).Dot("nextHook").Call()
 	callStatement := functionExpression.Call(argumentExpressions...)
-	callInstanceExpression := compose(addTypes(jen.Id(mockFuncCallStructName), iface.TypeParams, false), jen.Values(append(paramNames, resultNames...)...))
+	callInstanceExpression := compose(addTypes(jen.Id(mockFuncCallStructName), iface.TypeParams, outputImportPath, false), jen.Values(append(paramNames, resultNames...)...))
 	appendFuncCall := jen.Id("m").Dot(mockFuncFieldName).Dot("appendCall").Call(callInstanceExpression)
 	returnStatement := jen.Return()
 
@@ -70,7 +70,7 @@ func generateMockMethod(
 		params = append(params, compose(jen.Id(fmt.Sprintf("v%d", i)), param))
 	}
 
-	receiver := compose(jen.Id("m").Op("*"), addTypes(jen.Id(iface.mockStructName), iface.TypeParams, false))
+	receiver := compose(jen.Id("m").Op("*"), addTypes(jen.Id(iface.mockStructName), iface.TypeParams, outputImportPath, false))
 	methodDeclaration := jen.Func().Params(receiver).Id(method.Name).Params(params...).Params(method.resultTypes...).Block(body...)
 	return addComment(methodDeclaration, 1, commentText)
 }

--- a/internal/mockgen/generation/generate_structs.go
+++ b/internal/mockgen/generation/generate_structs.go
@@ -28,12 +28,12 @@ func generateMockStruct(iface *wrappedInterface, outputImportPath string) jen.Co
 			method.Name,
 		)
 
-		hook := compose(jen.Id(mockFuncFieldName).Op("*"), addTypes(jen.Id(mockFuncStructName), iface.TypeParams, false))
+		hook := compose(jen.Id(mockFuncFieldName).Op("*"), addTypes(jen.Id(mockFuncStructName), iface.TypeParams, outputImportPath, false))
 		structFields = append(structFields, addComment(hook, 2, commentText))
 	}
 
 	// <Name>Func *<Prefix><InterfaceName><Name>Func, ...
-	return generateStruct(mockStructName, iface.TypeParams, commentText, structFields)
+	return generateStruct(mockStructName, iface.TypeParams, commentText, outputImportPath, structFields)
 }
 
 func generateMockFuncStruct(iface *wrappedInterface, method *wrappedMethod, outputImportPath string) jen.Code {
@@ -47,11 +47,11 @@ func generateMockFuncStruct(iface *wrappedInterface, method *wrappedMethod, outp
 		mockStructName,
 	)
 
-	return generateStruct(mockFuncStructName, iface.TypeParams, commentText, []jen.Code{
-		compose(jen.Id("defaultHook"), method.signature),                                                      // defaultHook <signature>
-		compose(jen.Id("hooks").Index(), method.signature),                                                    // hooks []<signature>
-		compose(jen.Id("history").Index(), addTypes(jen.Id(mockFuncCallStructName), iface.TypeParams, false)), // history []<prefix>FuncCall
-		jen.Id("mutex").Qual("sync", "Mutex"),                                                                 // mutex sync.Mutex
+	return generateStruct(mockFuncStructName, iface.TypeParams, commentText, outputImportPath, []jen.Code{
+		compose(jen.Id("defaultHook"), method.signature),                                                                        // defaultHook <signature>
+		compose(jen.Id("hooks").Index(), method.signature),                                                                      // hooks []<signature>
+		compose(jen.Id("history").Index(), addTypes(jen.Id(mockFuncCallStructName), iface.TypeParams, outputImportPath, false)), // history []<prefix>FuncCall
+		jen.Id("mutex").Qual("sync", "Mutex"),                                                                                   // mutex sync.Mutex
 	})
 }
 
@@ -78,11 +78,11 @@ func generateMockFuncCallStruct(iface *wrappedInterface, method *wrappedMethod, 
 
 	argFields := makeFields("Arg", method.dotlessParamTypes, argFieldComment)    // Arg<n> <ParamType #n>, ...
 	resultFields := makeFields("Result", method.resultTypes, resultFieldComment) // Result<n> <ResultType #n>, ...
-	return generateStruct(mockFuncCallStructName, iface.TypeParams, commentText, append(argFields, resultFields...))
+	return generateStruct(mockFuncCallStructName, iface.TypeParams, commentText, outputImportPath, append(argFields, resultFields...))
 }
 
-func generateStruct(name string, typeParams []types.TypeParam, commentText string, structFields []jen.Code) jen.Code {
-	typeDeclaration := compose(addTypes(jen.Type().Id(name), typeParams, true), jen.Struct(structFields...))
+func generateStruct(name string, typeParams []types.TypeParam, commentText, outputImportPath string, structFields []jen.Code) jen.Code {
+	typeDeclaration := compose(addTypes(jen.Type().Id(name), typeParams, outputImportPath, true), jen.Struct(structFields...))
 	return addComment(typeDeclaration, 1, commentText)
 }
 

--- a/internal/mockgen/generation/util.go
+++ b/internal/mockgen/generation/util.go
@@ -27,7 +27,7 @@ func selfAppend(sliceRef *jen.Statement, value jen.Code) jen.Code {
 	return compose(sliceRef, jen.Op("=").Id("append").Call(sliceRef, value))
 }
 
-func addTypes(code *jen.Statement, typeParams []types.TypeParam, includeTypes bool) *jen.Statement {
+func addTypes(code *jen.Statement, typeParams []types.TypeParam, outputImportPath string, includeTypes bool) *jen.Statement {
 	if len(typeParams) == 0 {
 		return code
 	}
@@ -35,7 +35,7 @@ func addTypes(code *jen.Statement, typeParams []types.TypeParam, includeTypes bo
 	types := make([]jen.Code, 0, len(typeParams))
 	for _, typeParam := range typeParams {
 		if includeTypes {
-			types = append(types, compose(jen.Id(typeParam.Name), generateType(typeParam.Type, "", "", false)))
+			types = append(types, compose(jen.Id(typeParam.Name), generateType(typeParam.Type, "", outputImportPath, false)))
 		} else {
 			types = append(types, jen.Id(typeParam.Name))
 		}


### PR DESCRIPTION
When the bound of a generic is declared in the same package as the output package of the generated mocks, the output would attempt to import the current package, causing an import loop error in gopls (don't remember the error by go test). 

This fixes it by using the existing sanitizing routines but by passing the correct data down.