### PR TITLE
Optimistically continue on typecheck errors

### DIFF
--- a/internal/mockgen/types/extract.go
+++ b/internal/mockgen/types/extract.go
@@ -72,7 +72,12 @@ func gatherTypesForPackage(pkgs []*packages.Package, importPath, path string) (m
 		}
 
 		for _, err := range pkg.Errors {
-			return nil, fmt.Errorf("malformed package %s (%s)", importPath, err.Msg)
+			switch err.Kind {
+			case packages.TypeError:
+				log.Printf("package %s failed to type check, but attempting to continue: %s", importPath, err.Msg)
+			default:
+				return nil, fmt.Errorf("malformed package %s (%s)", importPath, err.Msg)
+			}
 		}
 
 		visitor := newVisitor(path, pkg.Types)


### PR DESCRIPTION
A frequent practical issue I run into when making changes is that I'll make a change to an interface, make a change to the implementor of an interface, but then `go-mockgen` does not successfully generate the new mock for the interface because the old mock interface does not successfully typecheck against code that uses it. 

This PR makes a small change to the logic to skip typechecking errors on package load and just log a warning instead. `go-mockgen` does not need the package to typecheck successfully to do its thing, it only really needs the package to parse. However, it doesn't really matter if there is a struct that doesn't correctly implement the interface. 

I couldn't figure out a way to add integration tests for this because, by nature of the change, the code that would be tested doesn't build, so any test files I would commit would fail to build. Here's how I manually tested it though:

Initialize a module:
```bash
go mod init github.com/camdencheek/test-mockgen
```

Create a file with an interface:

```go
package main

type Doer interface {
	Do(string)
}
```

Generate the mock:
```bash
go-mockgen -f -p main --import-path github.com/camdencheek/test-mockgen ./ -d ./
```

Modify the interface so that the old mock doesn't typecheck:
```go
package main

type Doer interface {
	Do(int)
}
```


Regenerate the mock, which now completes successfully even though the package fails to typecheck:
```bash
go-mockgen -f -p main --import-path github.com/camdencheek/test-mockgen ./ -d ./
```



