### PR TITLE
Update goIdentifierPattern regex

### DIFF
--- a/cmd/go-mockgen/args.go
+++ b/cmd/go-mockgen/args.go
@@ -303,7 +303,7 @@ func validateOutputPaths(opts *generation.Options) (bool, error) {
 	return false, nil
 }
 
-var goIdentifierPattern = regexp.MustCompile("^[A-Za-z]([A-Za-z0-9_]*[A-Za-z])?$")
+var goIdentifierPattern = regexp.MustCompile("^[A-Za-z]([A-Za-z0-9_]*)?$")
 
 func validateOptions(opts *generation.Options) (bool, error) {
 	for _, packageOpts := range opts.PackageOptions {


### PR DESCRIPTION
It seems the regex for identifying valid Go identifiers is wrong. 

According to the [Go source code](https://sourcegraph.com/github.com/golang/go/-/blob/src/go/token/token.go?L331),

 > An identifier is a non-empty string made up of letters, digits, and underscores, where the first character
 is not a digit. Keywords are not identifiers.

The regex defined in the library currently expects an identifier to begin and end with a letter.

```^[A-Za-z]([A-Za-z0-9_]*[A-Za-z])?$```

I switched the regex usage to fit the description of an identifier defined in Go. That way, `v1` can be identified as a valid package name.

I wonder if it is better to switch to using the `IsIdentifier` method from `go/token` instead of relying on a regex, let me know if this works so I can update the pull request to make use of this method instead of the regex.

![CleanShot 2024-01-04 at 04 14 53@2x](https://github.com/derision-test/go-mockgen/assets/25608335/5fd46178-8a39-402c-ad5e-d87fd6ee44ec)
