### PR TITLE
Update version to be displayed in generated mock file

### DIFF
--- a/internal/mockgen/consts/consts.go
+++ b/internal/mockgen/consts/consts.go
@@ -4,5 +4,5 @@ const (
 	Name        = "go-mockgen"
 	PackageName = "github.com/derision-test/go-mockgen/v2"
 	Description = "go-mockgen generates mock implementations from interface definitions."
-	Version     = "1.3.7"
+	Version     = "2.0.1"
 )


### PR DESCRIPTION
![CleanShot 2025-04-26 at 05 42 56@2x](https://github.com/user-attachments/assets/9def3dad-61a8-40d5-98d6-461b47c70908)

I'm on v2 of this library and the mock generated by `go-mockgen` still indicates I'm on `v1.3.7` which is wrong. Might be great to either not specify the version, or have the version update be a part of the release process. That way, the version of the next release is auto updated.